### PR TITLE
Update mirrorlist URL

### DIFF
--- a/usr/share/arcolinux-spices/scripts/get-the-keys-and-repos.sh
+++ b/usr/share/arcolinux-spices/scripts/get-the-keys-and-repos.sh
@@ -9,8 +9,9 @@ sudo wget https://github.com/arcolinux/arcolinux_repo/raw/main/x86_64/arcolinux-
 sudo pacman -U --noconfirm --needed /tmp/arcolinux-keyring-20251209-3-any.pkg.tar.zst
 
 echo "Getting the latest arcolinux mirrors file - report if link is broken"
-sudo wget https://github.com/arcolinux/arcolinux_repo/raw/main/x86_64/arcolinux-mirrorlist-git-24.03-12-any.pkg.tar.zst -O /tmp/arcolinux-mirrorlist-git-24.03-12-any.pkg.tar.zst
-sudo pacman -U --noconfirm --needed /tmp/arcolinux-mirrorlist-git-24.03-12-any.pkg.tar.zst
+sudo wget 
+https://github.com/arcolinux/arcolinux_repo/raw/main/x86_64/arcolinux-mirrorlist-git-25.04-05-any.pkg.tar.zst -O /tmp/arcolinux-mirrorlist-git-25.04-05-any.pkg.tar.zst
+sudo pacman -U --noconfirm --needed /tmp/arcolinux-mirrorlist-git-25.04-05-any.pkg.tar.zst
 	
 ######################################################################################################################
 


### PR DESCRIPTION
This PR updates the mirrorlist URL in the pacman configuration script to the latest version after last week's [update](https://github.com/arcolinux/arcolinux_repo/commit/87ec73df487db7306693f88217519d4b447e858d) broke it.